### PR TITLE
remove second instance of vine==1.3.0 (#1056)

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,4 @@
 celery>=4.3.0,<5.0.0; python_version>="3.7"
-vine==1.3.0
 tornado>=5.0.0,<7.0.0; python_version>="3.5.2"
 prometheus_client==0.8.0
 humanize


### PR DESCRIPTION
requirements.txt for some reason has duplicated vine version dependency declaration. One of them was removed in #1056, remove the second one now :(